### PR TITLE
키보드 바깥 빈 공간을 탭 시 키보드가 내려가게 수정

### DIFF
--- a/app/src/main/java/com/dogeby/tagplayer/ui/component/TagInputChipTextField.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/component/TagInputChipTextField.kt
@@ -1,6 +1,7 @@
 package com.dogeby.tagplayer.ui.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -26,9 +27,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -130,6 +134,16 @@ fun InputChipTextField(
                     }
                 },
             )
+        }
+    }
+}
+
+fun Modifier.clearFocusWhenTap(doOnClear: () -> Unit = {}): Modifier = composed {
+    val focusManager = LocalFocusManager.current
+    this.pointerInput(Unit) {
+        detectTapGestures {
+            focusManager.clearFocus()
+            doOnClear()
         }
     }
 }

--- a/app/src/main/java/com/dogeby/tagplayer/ui/tagsetting/TagSettingScreen.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/tagsetting/TagSettingScreen.kt
@@ -34,6 +34,7 @@ import com.dogeby.tagplayer.ui.component.TagInputChipTextField
 import com.dogeby.tagplayer.ui.component.TagManageMenuMoreHorizButton
 import com.dogeby.tagplayer.ui.component.TagNameEditDialog
 import com.dogeby.tagplayer.ui.component.VideoTag
+import com.dogeby.tagplayer.ui.component.clearFocusWhenTap
 import com.dogeby.tagplayer.ui.theme.TagPlayerTheme
 
 @Composable
@@ -81,7 +82,7 @@ fun TagSettingScreen(
     onHideTagNameEditDialog: () -> Unit = {},
 ) {
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.clearFocusWhenTap(),
         topBar = { TagSettingTopAppBar(onArrowBackButtonClick = onNavigateUp) },
     ) { contentPadding ->
         LazyColumn(


### PR DESCRIPTION
## Description
- TagSettingScreen에서 키보드가 올라와있을시 빈공간을 터치하면 textfield 포커스 해제
- 태그 클릭 시 포커스 해제 x, more button클릭하면 커서는 남아있고, 키보드는 내려감


resolved #60