### PR TITLE
동영상 카드 태그 잘리는 버그 해결 및 가시성 향상

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
         applicationId "com.dogeby.tagplayer"
         minSdk 26
         targetSdk 33
-        versionCode 11
-        versionName "1.1.4"
+        versionCode 12
+        versionName "1.1.5"
 
         testInstrumentationRunner "com.dogeby.tagplayer.TagPlayerTestRunner"
         vectorDrawables {

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
@@ -107,7 +107,6 @@ fun ExpandedVideoCard(
             else MaterialTheme.colorScheme.surfaceVariant,
         ),
         modifier = modifier
-            .aspectRatio(16 / (LocalConfiguration.current.fontScale * 10 + 5f))
             .clip(CardDefaults.shape)
             .combinedClickable(
                 onClick = { onClick(videoItem) },

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
@@ -122,15 +122,13 @@ fun ExpandedVideoCard(
         ) {
             Text(text = videoItem.name, maxLines = 2, overflow = TextOverflow.Ellipsis)
 
-            Spacer(modifier = Modifier.weight(1f))
-
-            val tagListItemHorizontalPadding = Modifier.padding(horizontal = dimensionResource(id = R.dimen.videolist_video_tag_list_item_horizontal_padding))
-            LazyRow {
+            val tagListItemEndPadding = Modifier.padding(end = dimensionResource(id = R.dimen.videolist_video_tag_list_item_end_padding))
+            LazyRow(modifier = Modifier.padding(top = 8.dp)) {
                 items(videoItem.parentDirectories) {
                     VideoTag(
                         name = it,
                         color = MaterialTheme.colorScheme.secondary,
-                        modifier = tagListItemHorizontalPadding,
+                        modifier = tagListItemEndPadding,
                     )
                 }
             }
@@ -139,7 +137,7 @@ fun ExpandedVideoCard(
                     VideoTag(
                         name = it.name,
                         color = MaterialTheme.colorScheme.tertiary,
-                        modifier = tagListItemHorizontalPadding,
+                        modifier = tagListItemEndPadding,
                     )
                 }
             }
@@ -209,7 +207,7 @@ fun ExpandedRippleLoadingVideoCard(
             Spacer(modifier = Modifier.weight(1f))
 
             val tagListItemModifier =
-                Modifier.padding(horizontal = dimensionResource(id = R.dimen.videolist_video_tag_list_item_horizontal_padding))
+                Modifier.padding(end = dimensionResource(id = R.dimen.videolist_video_tag_list_item_end_padding))
             Row {
                 repeat(2) {
                     RippleLoadingVideoTag(

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoInfoDialog.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoInfoDialog.kt
@@ -138,7 +138,7 @@ private fun VideoInfoTags(
                 VideoTag(
                     name = it.name,
                     color = MaterialTheme.colorScheme.tertiary,
-                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.videolist_video_tag_list_item_horizontal_padding)),
+                    modifier = Modifier.padding(end = dimensionResource(id = R.dimen.videolist_video_tag_list_item_end_padding)),
                 )
             }
         }

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoList.kt
@@ -134,14 +134,14 @@ private fun CompactVideoCard(
             ) {
                 Text(text = videoItem.name, maxLines = 2, overflow = TextOverflow.Ellipsis)
 
-                val tagListItemHorizontalPadding = Modifier.padding(horizontal = dimensionResource(id = R.dimen.videolist_video_tag_list_item_horizontal_padding))
+                val tagListItemEndPadding = Modifier.padding(end = dimensionResource(id = R.dimen.videolist_video_tag_list_item_end_padding))
                 Column(modifier = Modifier.align(Alignment.BottomStart)) {
                     LazyRow {
                         items(videoItem.parentDirectories) {
                             VideoTag(
                                 name = it,
                                 color = MaterialTheme.colorScheme.secondary,
-                                modifier = tagListItemHorizontalPadding,
+                                modifier = tagListItemEndPadding,
                             )
                         }
                     }
@@ -151,7 +151,7 @@ private fun CompactVideoCard(
                                 VideoTag(
                                     name = it.name,
                                     color = MaterialTheme.colorScheme.tertiary,
-                                    modifier = tagListItemHorizontalPadding,
+                                    modifier = tagListItemEndPadding,
                                 )
                             }
                         }
@@ -235,7 +235,7 @@ private fun CompactRippleLoadingVideoCard(
                     Spacer(modifier = Modifier.weight(1f))
 
                     val tagListItemModifier =
-                        Modifier.padding(horizontal = dimensionResource(id = R.dimen.videolist_video_tag_list_item_horizontal_padding))
+                        Modifier.padding(end = dimensionResource(id = R.dimen.videolist_video_tag_list_item_end_padding))
                     Row {
                         repeat(2) {
                             RippleLoadingVideoTag(

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,10 +14,10 @@
     <dimen name="videolist_setting_assist_chip_max_width">210dp</dimen>
     <dimen name="videolist_video_duration_horizontal_padding">2dp</dimen>
     <dimen name="videolist_video_thumbnail_duration_padding">4dp</dimen>
-    <dimen name="videolist_video_tag_list_item_horizontal_padding">2dp</dimen>
+    <dimen name="videolist_video_tag_list_item_end_padding">4dp</dimen>
     <dimen name="videolist_video_tag_horizontal_padding">4dp</dimen>
     <dimen name="videolist_compact_video_item_height">108dp</dimen>
-    <dimen name="videolist_video_item_info_padding">4dp</dimen>
+    <dimen name="videolist_video_item_info_padding">8dp</dimen>
     <dimen name="videolist_expanded_video_item_width">192dp</dimen>
 
     <dimen name="videoTag_min_width">32dp</dimen>


### PR DESCRIPTION
## Description

- 해상도 차이에 따라 유저 생성 동영상 태그가 잘리는 버그 해결
- 동영상 카드 padding 조절로 가시성 향상

resolved #233 
resolved #234