### PR TITLE
동영상 목록 화면 바텀바 애니메이션 방식에서 offset 조절로 수정

### DIFF
--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ContractedVideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ContractedVideoList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,9 +39,14 @@ fun ContractedVideoList(
     header: LazyListScope.() -> Unit = {},
     footer: LazyListScope.() -> Unit = {},
     onToggleVideoSelection: (VideoItem) -> Unit = {},
+    onScrollToEnd: (Boolean) -> Unit = {},
 ) {
+    val state = rememberLazyListState()
+    state.OnReachedEnd(onScrollToEnd)
+
     LazyColumn(
         modifier = modifier,
+        state = state,
         contentPadding = contentPadding,
         verticalArrangement = verticalArrangement,
         horizontalAlignment = horizontalAlignment,

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/ExpandedVideoList.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
@@ -17,6 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -51,10 +53,12 @@ fun ExpandedVideoList(
     isSelectedVideoItems: Map<Long, Boolean>,
     onNavigateToPlayer: (List<Long>, Long) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     verticalItemSpacing: Dp = dimensionResource(id = R.dimen.padding_small),
     horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_small)),
     videoItemContentPadding: PaddingValues = PaddingValues(0.dp),
     onToggleVideoSelection: (VideoItem) -> Unit = {},
+    onScrollToEnd: (Boolean) -> Unit = {},
 ) {
     if (videoItems.isEmpty()) {
         Box(
@@ -68,9 +72,14 @@ fun ExpandedVideoList(
         return
     }
 
+    val state = rememberLazyStaggeredGridState()
+    state.OnReachedEnd(onScrollToEnd)
+
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Adaptive(dimensionResource(id = R.dimen.videolist_expanded_video_item_width)),
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
+        state = state,
+        contentPadding = contentPadding,
         verticalItemSpacing = verticalItemSpacing,
         horizontalArrangement = horizontalArrangement,
     ) {

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoList.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoList.kt
@@ -2,6 +2,7 @@ package com.dogeby.tagplayer.ui.videolist
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,11 +18,16 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,9 +64,14 @@ fun CompactVideoList(
     header: LazyListScope.() -> Unit = {},
     footer: LazyListScope.() -> Unit = {},
     onToggleVideoSelection: (VideoItem) -> Unit = {},
+    onScrollToEnd: (Boolean) -> Unit = {},
 ) {
+    val state = rememberLazyListState()
+    state.OnReachedEnd(onScrollToEnd)
+
     LazyColumn(
         modifier = modifier,
+        state = state,
         contentPadding = contentPadding,
         verticalArrangement = verticalArrangement,
         horizontalAlignment = horizontalAlignment,
@@ -274,6 +285,18 @@ fun VideoListVideoThumbnail(
         durationShape = MaterialTheme.shapes.small,
         frameTimeMicrosecond = integerResource(id = R.integer.videolist_video_thumbnail_frameTimeMicrosecond).toLong(),
     )
+}
+
+@Composable
+fun ScrollableState.OnReachedEnd(onScrollToEnd: (Boolean) -> Unit) {
+    val isScrolledToEnd by remember {
+        derivedStateOf {
+            canScrollForward.not()
+        }
+    }
+    LaunchedEffect(isScrolledToEnd) {
+        onScrollToEnd(isScrolledToEnd)
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoListBottomAppBar.kt
+++ b/app/src/main/java/com/dogeby/tagplayer/ui/videolist/VideoListBottomAppBar.kt
@@ -1,7 +1,9 @@
 package com.dogeby.tagplayer.ui.videolist
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
@@ -14,11 +16,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import com.dogeby.tagplayer.R
 import com.dogeby.tagplayer.datastore.videolist.VideoListSortType
 import com.dogeby.tagplayer.ui.component.BottomAppBarAnimation
 import com.dogeby.tagplayer.ui.component.BottomAppBarAnimationIconButton
 import com.dogeby.tagplayer.ui.theme.TagPlayerTheme
+import kotlin.math.roundToInt
 
 @Composable
 fun VideoListBottomAppBar(
@@ -31,14 +35,21 @@ fun VideoListBottomAppBar(
     onSortTypeSet: (VideoListSortType) -> Unit,
     modifier: Modifier = Modifier,
     isShowActionIconAnimation: Boolean = true,
+    bottomBarOffsetHeightPx: (() -> Float) = { 0f }
 ) {
     var sortTypeMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    val animatedBottomBarOffsetHeightPx by animateFloatAsState(bottomBarOffsetHeightPx())
 
     BottomAppBarAnimation(
         shown = shown,
     ) {
         BottomAppBar(
-            modifier = modifier,
+            modifier = modifier.offset {
+                IntOffset(
+                    x = 0,
+                    y = -animatedBottomBarOffsetHeightPx.roundToInt()
+                )
+            },
         ) {
             BottomAppBarAnimationIconButton(
                 onClick = onSearchButtonClick,
@@ -71,7 +82,7 @@ fun VideoListBottomAppBar(
                 delayMillis = 300,
             ) {
                 Box(
-                    modifier = modifier
+                    modifier = Modifier
                         .wrapContentSize(Alignment.TopStart)
                 ) {
                     Icon(painter = painterResource(id = R.drawable.ic_sort), contentDescription = null)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,6 +19,7 @@
     <dimen name="videolist_compact_video_item_height">108dp</dimen>
     <dimen name="videolist_video_item_info_padding">8dp</dimen>
     <dimen name="videolist_expanded_video_item_width">192dp</dimen>
+    <dimen name="videolist_bottom_app_bar_height">80dp</dimen>
 
     <dimen name="videoTag_min_width">32dp</dimen>
 


### PR DESCRIPTION
## Description

- 동영상 목록 화면 바텀바 애니메이션 방식에서 offset 조절로 수정
- 동영상 목록 최하단 도달 시 바텀바 표시되게 구현
- Scaffold의 contentPadding이 list modifier가 아닌 contentPadding으로 들어가게 수정
- VideoListBottomAppBar의 검색 버튼의 modifier에 바텀바의 modifier가 들어간 문제 해결

resolved #242

## Screenshots
![움짤_동영상목록_바텀바개선](https://github.com/dogeby/tag-player/assets/68229193/e1792205-b8ce-4c7e-9b10-68d8a6ce7ec6)
